### PR TITLE
Bump golang and default tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ platform:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.18.1b7
+  image: rancher/hardened-build-base:v1.20.3b1
   commands:
   - make DRONE_TAG=${DRONE_TAG}
   volumes:
@@ -18,7 +18,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.18.1b7
+  image: rancher/hardened-build-base:v1.20.3b1
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
   - make DRONE_TAG=${DRONE_TAG} image-push
@@ -35,7 +35,7 @@ steps:
     - tag
 
 - name: scan
-  image: rancher/hardened-build-base:v1.18.1b7
+  image: rancher/hardened-build-base:v1.20.3b1
   commands:
   - make DRONE_TAG=${DRONE_TAG} image-scan
   volumes:
@@ -61,7 +61,7 @@ node:
 steps:
 - name: build
   pull: always
-  image: rancher/hardened-build-base:v1.18.1b7
+  image: rancher/hardened-build-base:v1.20.3b1
   failure: ignore
   commands:
   - make DRONE_TAG=${DRONE_TAG}
@@ -70,7 +70,7 @@ steps:
     path: /var/run/docker.sock
 
 - name: publish
-  image: rancher/hardened-build-base:v1.18.1b7
+  image: rancher/hardened-build-base:v1.20.3b1
   failure: ignore
   commands:
   - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG BCI_IMAGE=registry.suse.com/bci/bci-base:latest
-ARG GO_IMAGE=rancher/hardened-build-base:UNSET_GO_IMAGE_ARG
+ARG BCI_IMAGE=registry.suse.com/bci/bci-base:15.3.17.20.12
+ARG GO_IMAGE=rancher/hardened-build-base:1.20.3b1
 FROM ${BCI_IMAGE} as bci
 FROM ${GO_IMAGE} as builder
 # setup required packages
@@ -14,7 +14,7 @@ RUN set -x \
 # setup the build
 ARG PKG="github.com/kubernetes-sigs/cri-tools"
 ARG SRC="github.com/kubernetes-sigs/cri-tools"
-ARG TAG="v1.18.0"
+ARG TAG="v1.26.1"
 ARG ARCH="amd64"
 RUN git clone --depth=1 https://${SRC}.git $GOPATH/src/${PKG}
 WORKDIR $GOPATH/src/${PKG}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD_META=-build$(shell TZ=UTC date +%Y%m%d)
 ORG ?= rancher
 PKG ?= github.com/kubernetes-sigs/cri-tools
 SRC ?= github.com/kubernetes-sigs/cri-tools
-TAG ?= v1.23.0$(BUILD_META)
+TAG ?= v1.26.1$(BUILD_META)
 
 ifneq ($(DRONE_TAG),)
 TAG := $(DRONE_TAG)

--- a/scripts/golang-version.sh
+++ b/scripts/golang-version.sh
@@ -10,6 +10,13 @@ K8S_VERSION=$(./semver-parse.sh $1 all)
 DEPENDENCIES_URL="https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/dependencies.yaml"
 GOBORING_RELEASES_URL="https://raw.githubusercontent.com/golang/go/dev.boringcrypto/misc/boring/RELEASES"
 GOLANG_VERSION=$(curl -sL "${DEPENDENCIES_URL}" | yq e '.dependencies[] | select(.name == "golang: upstream version").version' -)
-GOBORING_VERSION=$(curl -sL  "${GOBORING_RELEASES_URL}" | awk "/${GOLANG_VERSION}b.+ [0-9a-f]+ src / {sub(/^go/, \"v\", \$1); print \$1}")
+GOLANG_MINOR=$(echo $GOLANG_VERSION | awk -F. '{print $2}')
+
+# goboring is built into golang as of 1.19; tag is 'b1' for all releases
+if [ "$GOLANG_MINOR" -ge "19" ]; then
+  GOBORING_VERSION="v${GOLANG_VERSION}b1"
+else
+  GOBORING_VERSION=$(curl -sL  "${GOBORING_RELEASES_URL}" | awk "/${GOLANG_VERSION}b.+ [0-9a-f]+ src / {sub(/^go/, \"v\", \$1); print \$1}")
+fi
 
 echo ${GOBORING_VERSION}


### PR DESCRIPTION
Bump to latest versions.

Also fix golang version script; goboring version will be `b1` for all 1.19+ golang releases.