### PR TITLE
Add grpc go-mod-override for GHSA-hrxh-6v49-42gf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN set -x; \
     for MODULE in $(go mod edit --json | jq -r '.Replace[] | select(.Old.Path | test("^k8s.io/")) | select(.Old.Path | test("^k8s.io/(kubernetes|klog|utils|kube-openapi)") | not) | .Old.Path'); do go mod edit --replace ${MODULE}=${MODULE}@${K8S_VERSION_MOD}; done; \
     for MODULE in $(go mod edit --json | jq -r '.Require[] | select(.Path | test("^k8s.io/")) | select(.Path | test("^k8s.io/(kubernetes|klog|utils|kube-openapi)") | not) | .Path'); do go mod edit --require ${MODULE}@${K8S_VERSION_MOD}; done; \
     go mod tidy && go mod vendor
+COPY go-mod-overrides ./go-mod-overrides
+RUN go-mod-overrides.sh ./go-mod-overrides
 RUN GO_LDFLAGS="-linkmode=external -X $(awk '/^module /{print $2}' go.mod)/pkg/version.Version=${TAG}" \
     go-build-static.sh -gcflags=-trimpath=${GOPATH}/src -o bin/crictl ./cmd/crictl
 RUN go-assert-static.sh bin/*

--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,0 +1,3 @@
+# google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
+# Drop once upstream requires google.golang.org/grpc >= v1.82.1.
+-replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1


### PR DESCRIPTION
Adds a `go-mod-overrides` file pinning `google.golang.org/grpc` to **v1.82.1** to remediate **GHSA-hrxh-6v49-42gf** (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS), and wires it into the Dockerfile via the shared `go-mod-overrides.sh` script (same pattern as sibling image-build repos, e.g. rancher/image-build-external-snapshotter#16).

The binaries build from the root module, so the root replace applies directly. Verified locally: after the override, `go mod tidy && go mod vendor` succeed and the built binary links `google.golang.org/grpc v1.82.1`.

Drop once upstream requires `google.golang.org/grpc >= v1.82.1`.