### PR TITLE
Add x/net go-mod-override to bump golang.org/x/net to v0.55.0

### DIFF
--- a/go-mod-overrides
+++ b/go-mod-overrides
@@ -1,3 +1,6 @@
 # google.golang.org/grpc: GHSA-hrxh-6v49-42gf (xDS RBAC auth bypass, HTTP/2 Rapid Reset DoS).
 # Drop once upstream requires google.golang.org/grpc >= v1.82.1.
 -replace google.golang.org/grpc=google.golang.org/grpc@v1.82.1
+
+# golang.org/x/net: security fix. Drop once upstream requires golang.org/x/net >= v0.55.0.
+-replace golang.org/x/net=golang.org/x/net@v0.55.0


### PR DESCRIPTION
This pins golang.org/x/net to v0.55.0 via the `go-mod-overrides` file to remediate a security issue in the transitively pulled version.

It follows the same pattern as the already merged PR #103, which added the google.golang.org/grpc override: a single line is appended to the root `go-mod-overrides` file, which the shared `go-mod-overrides.sh` script (from hardened-build-base) passes verbatim to `go mod edit`. No changes to the Dockerfile or the script are needed.

This override should be dropped once upstream cri-tools requires golang.org/x/net >= v0.55.0.